### PR TITLE
gcc-config: fix cross-compiler detection

### DIFF
--- a/gcc-config
+++ b/gcc-config
@@ -182,7 +182,7 @@ get_chost() {
 }
 
 is_cross_compiler() {
-	[[ ${CC_COMP/${CHOST}} == ${CC_COMP} ]]
+	[[ ${CHOST} != ${CC_COMP_TARGET} ]]
 }
 
 is_same_mountpoint() {


### PR DESCRIPTION
Compiler can be missdetected as native compiler if CHOST is a substring of CTARGET.

Bug: https://bugs.gentoo.org/962211